### PR TITLE
install a C++11-capable compiler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+ sudo: false
+ env:
+   - CXX=g++-4.8
  language: node_js
  node_js:
    - "0.8"
@@ -6,6 +9,12 @@
    - "0.12"
    - "iojs"
    - "4.0"
-
+ addons:
+   apt:
+     sources:
+       - ubuntu-toolchain-r-test
+     packages:
+       - gcc-4.8
+       - g++-4.8
  before_install:
    - "test $TRAVIS_NODE_VERSION != '0.8' || npm install -g npm@1.2.8000"


### PR DESCRIPTION
The issue bnoordhuis/node-iconv#132 can be resolved by a mere installing of a C++11-capable compiler.

See also Travis CI job logs for [iojs](https://travis-ci.org/Mithgol/iconv-lite/jobs/79810607) and [Node.js v4.0.0](https://travis-ci.org/Mithgol/iconv-lite/jobs/79810608).